### PR TITLE
Fix loss of incoming connections

### DIFF
--- a/.release-notes/63.md
+++ b/.release-notes/63.md
@@ -1,0 +1,4 @@
+## Fix loss of incoming connections
+
+Incoming connections that arrived close together might sometimes be accepted by the OS but never handled by Lori.
+

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -83,7 +83,6 @@ class TCPListener
             return
           else
             e.on_accept(fd)
-            return
           end
         end
       end


### PR DESCRIPTION
Accept will queue multiple requests together in a single notification
via epoll so you need to keep looking until it returns no additional
results.