### PR TITLE
Only run tests when doing `make test`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
 
   test_script:
     - export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
-    - gmake test config=release
+    - gmake ci config=release
 
 task:
   freebsd_instance:
@@ -30,4 +30,4 @@ task:
 
   test_script:
     - export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
-    - gmake test config=debug
+    - gmake ci config=debug

--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc
-        run: make test config=release
+        run: make ci config=release
 
   debug-vs-ponyc-main:
     name: Verify in debug mode on Linux with most recent ponyc
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc
-        run: make test config=debug
+        run: make ci config=debug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc release
-        run: make test config=release
+        run: make ci config=release
 
   debug-vs-ponyc-release:
     name: Verify debug mode on Linux with most recent ponyc release
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc release
-        run: make test config=debug
+        run: make ci config=debug
 
   macos-debug-vs-ponyc-release:
     name: Verify PR builds on macOS with most recent ponyc release
@@ -58,7 +58,7 @@ jobs:
       - name: Test with the most recent ponyc release
         run: |
           export PATH=/Users/runner/.local/share/ponyup/bin/:$PATH
-          make test config=debug
+          make ci config=debug
 
   macos-release-vs-ponyc-release:
     name: Verify PR builds on macOS with most recent ponyc release
@@ -70,4 +70,4 @@ jobs:
       - name: Test with the most recent ponyc release
         run: |
           export PATH=/Users/runner/.local/share/ponyup/bin/:$PATH
-          make test config=release
+          make ci config=release

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name \*.pony)
 
-test: unit-tests build-examples
+test: unit-tests
+
+ci: unit-tests build-examples
+
+examples: build-examples
 
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential


### PR DESCRIPTION
Adds a new `ci` target that runs both unit-tests and builds the
examples.

Closes #18