### PR TITLE
Rename on_failure callback to on_connection_failure

### DIFF
--- a/.release-notes/79.md
+++ b/.release-notes/79.md
@@ -1,0 +1,5 @@
+## Rename `on_failure` callback to `on_connection_failure`
+
+`on_failure` is very generic and doesn't state what the failure was. When someone is using lori, they will have an `on_failure` callback that could be any number of failures for that actor. Switching the name to `on_connection_failure` should make it considerably more clear.
+
+Adjusting to this change is as simple as finding any usage you had of `of_failure` and replacing it with `on_connection_failure`.

--- a/examples/echo-server/echo-server.pony
+++ b/examples/echo-server/echo-server.pony
@@ -28,7 +28,7 @@ actor EchoServer is TCPListenerActor
   fun ref on_closed() =>
     _out.print("Echo server shut down.")
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     _out.print("Couldn't start Echo server. " +
       "Perhaps try another network interface?")
 

--- a/examples/infinite-ping-pong/infinite-ping-pong.pony
+++ b/examples/infinite-ping-pong/infinite-ping-pong.pony
@@ -32,7 +32,7 @@ actor  Listener is TCPListenerActor
   fun ref on_listening() =>
     Client(_connect_auth, "127.0.0.1", "7669", "", _out)
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     _out.print("Unable to open listener")
 
 actor Server is TCPServerActor

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -91,7 +91,7 @@ actor _TestOutgoingFailure is TCPClientActor
   fun ref on_connected() =>
     _h.fail("on_connected for a connection that should have failed")
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     _h.complete(true)
 
 class iso _PingPong is UnitTest
@@ -200,7 +200,7 @@ actor _TestPongerListener is TCPListenerActor
     let auth = TCPConnectAuth(_h.env.root)
     _pinger = _TestPinger(auth, _pings_to_receive, _h)
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     _h.fail("Unable to open _TestPongerListener")
 
 class iso _TestBasicExpect is UnitTest
@@ -266,7 +266,7 @@ actor _TestBasicExpectListener is TCPListenerActor
     _h.complete_action("server listening")
     _client =_TestBasicExpectClient(_client_auth, _h)
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     _h.fail("Unable to open _TestBasicExpectListener")
 
 actor _TestBasicExpectServer is TCPServerActor

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -268,7 +268,7 @@ class TCPConnection
             PonyAsio.unsubscribe(event)
             PonyTCP.close(fd)
             close()
-            c.on_failure()
+            c.on_connection_failure()
           end
         end
       end

--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -5,7 +5,7 @@ trait tag TCPClientActor is TCPConnectionActor
     """
     None
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     """
     Called when a connection fails to open
     """

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -17,7 +17,7 @@ class TCPListener
       state = Open
       enclosing.on_listening()
     else
-      enclosing.on_failure()
+      enclosing.on_connection_failure()
     end
 
   new none() =>

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -12,7 +12,7 @@ trait tag TCPListenerActor is AsioEventNotify
     """
     None
 
-  fun ref on_failure() =>
+  fun ref on_connection_failure() =>
     """
     Called if we are unable to open the listener
     """


### PR DESCRIPTION
"on_failure" is very generic and doesn't state what the failure was. When someone is using lori, they will have an "on_failure" callback that could be any number of failures for that actor. Switching the name to "on_connection_failure" should make it considerably more clear.

Closes #78