### PR TITLE
Make lori callbacks private

### DIFF
--- a/.release-notes/80.md
+++ b/.release-notes/80.md
@@ -1,0 +1,3 @@
+## Make Lori callbacks private
+
+All the callbacks on `TCPClientActor`, `TCPServerActor`, and `TCPConnectionActor` have been changed to private from public. This better indicates that the methods are not intended to be called from outside of Lori. To update, you'll need to make the methods on your objects that implement any of the above traits private as well.

--- a/examples/echo-server/echo-server.pony
+++ b/examples/echo-server/echo-server.pony
@@ -6,7 +6,7 @@ actor Main
     let echo = EchoServer(auth, "", "7669", env.out)
 
 actor EchoServer is TCPListenerActor
-  var _listener: TCPListener = TCPListener.none()
+  var _tcp_listener: TCPListener = TCPListener.none()
   let _out: OutStream
   let _server_auth: TCPServerAuth
 
@@ -17,41 +17,41 @@ actor EchoServer is TCPListenerActor
   =>
     _out = out
     _server_auth = TCPServerAuth(listen_auth)
-    _listener = TCPListener(listen_auth, host, port, this)
+    _tcp_listener = TCPListener(listen_auth, host, port, this)
 
-  fun ref listener(): TCPListener =>
-    _listener
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
 
-  fun ref on_accept(fd: U32): TCPConnectionActor =>
+  fun ref _on_accept(fd: U32): TCPConnectionActor =>
     Echoer(_server_auth, fd, _out)
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     _out.print("Echo server shut down.")
 
-  fun ref on_connection_failure() =>
+  fun ref _on_connection_failure() =>
     _out.print("Couldn't start Echo server. " +
       "Perhaps try another network interface?")
 
-  fun ref on_listening() =>
+  fun ref _on_listening() =>
     _out.print("Echo server started.")
 
 actor Echoer is TCPServerActor
-  var _connection: TCPConnection = TCPConnection.none()
+  var _tcp_connection: TCPConnection = TCPConnection.none()
   let _out: OutStream
 
   new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
     _out = out
-    _connection = TCPConnection.server(auth, fd, this)
+    _tcp_connection = TCPConnection.server(auth, fd, this)
 
-  fun ref connection(): TCPConnection =>
-    _connection
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     _out.print("Connection Closed")
 
-  fun ref on_connected(conn: TCPConnection ref) =>
+  fun ref _on_connected(conn: TCPConnection ref) =>
     _out.print("We have a new connection!")
 
-  fun ref on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso) =>
     _out.print("Data received. Echoing it back.")
-    _connection.send(consume data)
+    _tcp_connection.send(consume data)

--- a/examples/infinite-ping-pong/infinite-ping-pong.pony
+++ b/examples/infinite-ping-pong/infinite-ping-pong.pony
@@ -9,7 +9,7 @@ actor Main
     Listener(listen_auth, connect_auth, env.out)
 
 actor  Listener is TCPListenerActor
-  var _listener: TCPListener = TCPListener.none()
+  var _tcp_listener: TCPListener = TCPListener.none()
   let _out: OutStream
   let _connect_auth: TCPConnectAuth
   let _server_auth: TCPServerAuth
@@ -21,37 +21,37 @@ actor  Listener is TCPListenerActor
     _connect_auth = connect_auth
     _out = out
     _server_auth = TCPServerAuth(listen_auth)
-    _listener = TCPListener(listen_auth, "127.0.0.1", "7669", this)
+    _tcp_listener = TCPListener(listen_auth, "127.0.0.1", "7669", this)
 
-  fun ref listener(): TCPListener =>
-    _listener
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
 
-  fun ref on_accept(fd: U32): Server =>
+  fun ref _on_accept(fd: U32): Server =>
     Server(_server_auth, fd, _out)
 
-  fun ref on_listening() =>
+  fun ref _on_listening() =>
     Client(_connect_auth, "127.0.0.1", "7669", "", _out)
 
-  fun ref on_connection_failure() =>
+  fun ref _on_connection_failure() =>
     _out.print("Unable to open listener")
 
 actor Server is TCPServerActor
-  var _connection: TCPConnection = TCPConnection.none()
+  var _tcp_connection: TCPConnection = TCPConnection.none()
   let _out: OutStream
 
   new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
     _out = out
-    _connection =  TCPConnection.server(auth, fd, this)
+    _tcp_connection =  TCPConnection.server(auth, fd, this)
 
-  fun ref connection(): TCPConnection =>
-    _connection
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
 
-  fun ref on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso) =>
     _out.print(consume data)
-    _connection.send("Pong")
+    _tcp_connection.send("Pong")
 
 actor Client is TCPClientActor
-  var _connection: TCPConnection = TCPConnection.none()
+  var _tcp_connection: TCPConnection = TCPConnection.none()
   let _out: OutStream
 
   new create(auth: TCPConnectAuth,
@@ -61,14 +61,14 @@ actor Client is TCPClientActor
     out: OutStream)
   =>
     _out = out
-    _connection = TCPConnection.client(auth, host, port, from, this)
+    _tcp_connection = TCPConnection.client(auth, host, port, from, this)
 
-  fun ref connection(): TCPConnection =>
-    _connection
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
 
-  fun ref on_connected() =>
-   _connection.send("Ping")
+  fun ref _on_connected() =>
+   _tcp_connection.send("Ping")
 
-  fun ref on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso) =>
    _out.print(consume data)
-   _connection.send("Ping")
+   _tcp_connection.send("Ping")

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -160,7 +160,7 @@ class TCPConnection
               (let data', _read_buffer) = (consume x).chop(bytes_to_consume)
               _bytes_in_read_buffer = _bytes_in_read_buffer - bytes_to_consume
 
-              s.on_received(consume data')
+              s._on_received(consume data')
             end
 
             if total_bytes_read >= _read_buffer_size then
@@ -209,7 +209,7 @@ class TCPConnection
     | let s: TCPConnectionActor ref =>
       if not is_throttled() then
         throttled()
-        s.on_throttled()
+        s._on_throttled()
       end
     | None =>
       // TODO: Blow up here!
@@ -221,7 +221,7 @@ class TCPConnection
     | let s: TCPConnectionActor ref =>
       if is_throttled() then
         unthrottled()
-        s.on_unthrottled()
+        s._on_unthrottled()
       end
     | None =>
       // TODO: blow up here
@@ -262,13 +262,13 @@ class TCPConnection
             _event = event
             _fd = fd
             open()
-            c.on_connected()
+            c._on_connected()
             read()
           else
             PonyAsio.unsubscribe(event)
             PonyTCP.close(fd)
             close()
-            c.on_connection_failure()
+            c._on_connection_failure()
           end
         end
       end

--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -1,11 +1,11 @@
 trait tag TCPClientActor is TCPConnectionActor
-  fun ref on_connected() =>
+  fun ref _on_connected() =>
     """
     Called when a connection is opened
     """
     None
 
-  fun ref on_connection_failure() =>
+  fun ref _on_connection_failure() =>
     """
     Called when a connection fails to open
     """
@@ -14,27 +14,27 @@ trait tag TCPClientActor is TCPConnectionActor
 trait tag TCPServerActor is TCPConnectionActor
 
 trait tag TCPConnectionActor is AsioEventNotify
-  fun ref connection(): TCPConnection
+  fun ref _connection(): TCPConnection
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     """
     Called when the connection is closed
     """
     None
 
-  fun ref on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso) =>
     """
     Called each time data is received on this connection
     """
     None
 
-  fun ref on_throttled() =>
+  fun ref _on_throttled() =>
     """
     Called when we start experiencing backpressure
     """
     None
 
-  fun ref on_unthrottled() =>
+  fun ref _on_unthrottled() =>
     """
     Called when backpressure is released
     """
@@ -44,13 +44,13 @@ trait tag TCPConnectionActor is AsioEventNotify
     """
     Close connection
     """
-    connection().close()
+    _connection().close()
 
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    connection().event_notify(event, flags, arg)
+    _connection().event_notify(event, flags, arg)
 
   be _read_again() =>
     """
     Resume reading
     """
-    connection().read()
+    _connection().read()

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -15,9 +15,9 @@ class TCPListener
       _fd = PonyAsio.event_fd(event)
       _event = event
       state = Open
-      enclosing.on_listening()
+      enclosing._on_listening()
     else
-      enclosing.on_connection_failure()
+      enclosing._on_connection_failure()
     end
 
   new none() =>
@@ -36,7 +36,7 @@ class TCPListener
           PonyAsio.unsubscribe(_event)
           PonyTCP.close(_fd)
           _fd = -1
-          e.on_closed()
+          e._on_closed()
         end
       end
     | None =>
@@ -80,7 +80,7 @@ class TCPListener
             // Would block. Bail out.
             return
           else
-            e.on_accept(fd)
+            e._on_accept(fd)
           end
         end
       end

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -1,24 +1,24 @@
 trait tag TCPListenerActor is AsioEventNotify
-  fun ref listener(): TCPListener
+  fun ref _listener(): TCPListener
 
-  fun ref on_accept(fd: U32): TCPConnectionActor
+  fun ref _on_accept(fd: U32): TCPConnectionActor
     """
     Called when a connection is accepted
     """
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     """
     Called after the listener is closed
     """
     None
 
-  fun ref on_connection_failure() =>
+  fun ref _on_connection_failure() =>
     """
     Called if we are unable to open the listener
     """
     None
 
-  fun ref on_listening() =>
+  fun ref _on_listening() =>
     """
     Called once the listener is ready to accept connections
     """
@@ -28,7 +28,7 @@ trait tag TCPListenerActor is AsioEventNotify
     """
     Stop listening
     """
-    listener().close()
+    _listener().close()
 
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    listener().event_notify(event, flags, arg)
+    _listener().event_notify(event, flags, arg)


### PR DESCRIPTION
There's no need for the callbacks to be public, so I'm making them private. They aren't intended to be called from code outside of Lori and this makes it a bit more specific.

Closes #77