### PR TITLE
Remove FreeBSD pony install tools

### DIFF
--- a/.ci-scripts/freebsd-13-install-nightly-pony-tools.bash
+++ b/.ci-scripts/freebsd-13-install-nightly-pony-tools.bash
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
-
-export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
-
-ponyup update ponyc nightly

--- a/.ci-scripts/freebsd-13-install-release-pony-tools.bash
+++ b/.ci-scripts/freebsd-13-install-release-pony-tools.bash
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
-
-export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
-
-ponyup update ponyc release


### PR DESCRIPTION
We don't test on FreeBSD anymore so these aren't needed. CirrusCI became unfree so we have no FreeBSD test environment.